### PR TITLE
feat: Add My Bookmarks modal with tabbed interface

### DIFF
--- a/src/components/modals/MyBookmarksModal.jsx
+++ b/src/components/modals/MyBookmarksModal.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog.jsx";
+import { Button } from "@/components/ui/button.jsx";
+import { cn } from "@/lib/utils.js";
+
+const MyBookmarksModal = ({ isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  const [activeTab, setActiveTab] = useState('founder'); // 'founder', 'investor', 'projects'
+
+  const tabs = [
+    { id: 'founder', label: 'Founder Profiles' },
+    { id: 'investor', label: 'Investor Profiles' },
+    { id: 'projects', label: 'Saved Projects' },
+  ];
+
+  const renderContent = () => {
+    const contentBaseClass = "p-4 min-h-[200px] flex items-center justify-center";
+    const animationClass = "animate-fadeIn"; // Defined in Tailwind config
+
+    switch (activeTab) {
+      case 'founder':
+        return <div key="founder" className={`${contentBaseClass} ${animationClass}`}><p className="text-gray-500 dark:text-gray-400">List of bookmarked founder profiles.</p></div>;
+      case 'investor':
+        return <div key="investor" className={`${contentBaseClass} ${animationClass}`}><p className="text-gray-500 dark:text-gray-400">List of bookmarked investor profiles.</p></div>;
+      case 'projects':
+        return <div key="projects" className={`${contentBaseClass} ${animationClass}`}><p className="text-gray-500 dark:text-gray-400">List of saved projects.</p></div>;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-xl w-full p-0 bg-white dark:bg-gray-900 rounded-lg shadow-xl overflow-hidden">
+        <DialogHeader className="px-4 py-3 sm:px-6 sm:py-4 border-b border-gray-200 dark:border-zinc-700">
+          <DialogTitle className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white">
+            My Bookmarks
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex border-b border-gray-200 dark:border-zinc-700">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                "flex-1 py-2 px-2 text-xs sm:py-3 sm:px-4 sm:text-sm font-medium text-center focus:outline-none transition-colors duration-150",
+                activeTab === tab.id
+                  ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400"
+                  : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800"
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="p-4 sm:p-6">
+          {renderContent()}
+        </div>
+
+        <div className="px-4 py-3 sm:px-6 sm:py-4 border-t border-gray-200 dark:border-zinc-700 flex justify-end">
+          <Button variant="outline" onClick={onClose} className="dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-700">
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default MyBookmarksModal;

--- a/src/components/modals/MyBookmarksModal.test.jsx
+++ b/src/components/modals/MyBookmarksModal.test.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom'; // For extended matchers like .toBeVisible()
+import MyBookmarksModal from './MyBookmarksModal.jsx';
+
+// Mock the cn utility if it's not automatically handled by the test environment
+// jest.mock('@/lib/utils.js', () => ({
+//   cn: (...args) => args.filter(Boolean).join(' '),
+// }));
+
+describe('MyBookmarksModal', () => {
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    // Clear mock calls before each test
+    mockOnClose.mockClear();
+  });
+
+  test('renders modal with title and default tab when isOpen is true', () => {
+    render(<MyBookmarksModal isOpen={true} onClose={mockOnClose} />);
+    expect(screen.getByText('My Bookmarks')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Founder Profiles' })).toBeVisible();
+    // Check for default tab content
+    expect(screen.getByText('List of bookmarked founder profiles.')).toBeVisible();
+  });
+
+  test('does not render modal content when isOpen is false', () => {
+    render(<MyBookmarksModal isOpen={false} onClose={mockOnClose} />);
+    // The component returns null when isOpen is false
+    expect(screen.queryByText('My Bookmarks')).not.toBeInTheDocument();
+  });
+
+  test('initially displays "Founder Profiles" tab as active and its content', () => {
+    render(<MyBookmarksModal isOpen={true} onClose={mockOnClose} />);
+    const founderTabButton = screen.getByRole('button', { name: 'Founder Profiles' });
+    // A simple way to check for active might be through its attributes if styled distinctively,
+    // or by checking if its content is visible.
+    expect(founderTabButton).toBeVisible(); // Implicitly, it's the active one by default
+    expect(screen.getByText('List of bookmarked founder profiles.')).toBeVisible();
+  });
+
+  test('switches tabs and displays corresponding content when tab buttons are clicked', () => {
+    render(<MyBookmarksModal isOpen={true} onClose={mockOnClose} />);
+
+    // Click Investor Profiles tab
+    const investorTabButton = screen.getByRole('button', { name: 'Investor Profiles' });
+    fireEvent.click(investorTabButton);
+    expect(screen.getByText('List of bookmarked investor profiles.')).toBeVisible();
+    expect(screen.queryByText('List of bookmarked founder profiles.')).not.toBeInTheDocument();
+
+    // Click Saved Projects tab
+    const projectsTabButton = screen.getByRole('button', { name: 'Saved Projects' });
+    fireEvent.click(projectsTabButton);
+    expect(screen.getByText('List of saved projects.')).toBeVisible();
+    expect(screen.queryByText('List of bookmarked investor profiles.')).not.toBeInTheDocument();
+
+    // Click back to Founder Profiles tab
+    const founderTabButton = screen.getByRole('button', { name: 'Founder Profiles' });
+    fireEvent.click(founderTabButton);
+    expect(screen.getByText('List of bookmarked founder profiles.')).toBeVisible();
+    expect(screen.queryByText('List of saved projects.')).not.toBeInTheDocument();
+  });
+
+  test('calls onClose prop when the Close button is clicked', () => {
+    render(<MyBookmarksModal isOpen={true} onClose={mockOnClose} />);
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    fireEvent.click(closeButton);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  // Example for testing animation class (more advanced, might need setup)
+  // test('applies animation class to tab content', async () => {
+  //   render(<MyBookmarksModal isOpen={true} onClose={mockOnClose} />);
+  //   const founderContent = screen.getByText('List of bookmarked founder profiles.').closest('div');
+  //   expect(founderContent).toHaveClass('animate-fadeIn');
+  // });
+});

--- a/src/loop-ai-dashboard.jsx
+++ b/src/loop-ai-dashboard.jsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/dropdown-menu.jsx"
 import { AppDownloadModal } from "./components/app-download-modal.jsx"
 import LoginModal from "./components/modals/LoginModal.jsx";
+import MyBookmarksModal from "./components/modals/MyBookmarksModal.jsx"; // Added import
 import { BuyLimitModal } from "./components/buy-limit-modal.jsx"
 import { NeedHelpModal } from "./components/need-help-modal.jsx"
 
@@ -53,6 +54,7 @@ export default function Component() {
   const [isInputFocused, setIsInputFocused] = useState(false)
   const [showDownloadModal, setShowDownloadModal] = useState(false)
   const [showLoginModal, setShowLoginModal] = useState(false);
+  const [showMyBookmarksModal, setShowMyBookmarksModal] = useState(false); // Added state
   const [showBuyLimitModal, setShowBuyLimitModal] = useState(false)
   const [showNeedHelpModal, setShowNeedHelpModal] = useState(false)
   const inputRef = useRef(null)
@@ -345,7 +347,7 @@ export default function Component() {
                   <span>Updates</span>
                   <ChevronRight className="w-4 h-4 ml-auto" />
                 </DropdownMenuItem>
-                <DropdownMenuItem className="flex items-center gap-3 text-sm py-2">
+                <DropdownMenuItem onClick={() => setShowMyBookmarksModal(true)} className="flex items-center gap-3 text-sm py-2"> {/* Added onClick */}
                   <div className="w-4 h-4 bg-gray-100 dark:bg-zinc-700 rounded flex items-center justify-center">
                     <div className="w-2 h-2 bg-gray-400 rounded"></div>
                   </div>
@@ -396,7 +398,7 @@ export default function Component() {
                   <Bell className="w-4 h-4 text-blue-500" />
                   <span>Updates</span>
                 </DropdownMenuItem>
-                <DropdownMenuItem className="flex items-center gap-2 text-sm">
+                <DropdownMenuItem onClick={() => setShowMyBookmarksModal(true)} className="flex items-center gap-2 text-sm"> {/* Added onClick */}
                   <Bookmark className="w-4 h-4 text-gray-500" />
                   <span>My Bookmarks</span>
                 </DropdownMenuItem>
@@ -749,6 +751,12 @@ export default function Component() {
 
       {/* Need Help Modal */}
       <NeedHelpModal isOpen={showNeedHelpModal} onClose={() => setShowNeedHelpModal(false)} />
+
+      {/* My Bookmarks Modal */}
+      <MyBookmarksModal
+        isOpen={showMyBookmarksModal}
+        onClose={() => setShowMyBookmarksModal(false)}
+      />
     </div>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -70,10 +70,15 @@ const config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        fadeIn: {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        fadeIn: 'fadeIn 0.5s ease-in-out',
       },
     },
   },


### PR DESCRIPTION
I've implemented a new modal for "My Bookmarks" accessible from the sidebar's Quick Access menu.

Key features:
- The modal displays three tabs: "Founder Profiles," "Investor Profiles," and "Saved Projects."
- Basic tab switching functionality with a fade-in animation is included.
- Placeholder content is added for each tab, ready for future API integration.
- The modal is responsive and styled consistently with the application theme.
- I've included basic unit tests for the modal's functionality.

Changes:
- I created `src/components/modals/MyBookmarksModal.jsx` for the modal component.
- I updated `src/loop-ai-dashboard.jsx` to integrate and trigger the modal.
- I modified `tailwind.config.js` to include a `fadeIn` animation.
- I added `src/components/modals/MyBookmarksModal.test.jsx` with unit tests.